### PR TITLE
Add Marketlens to data tooling

### DIFF
--- a/data/tools/marketlens.yaml
+++ b/data/tools/marketlens.yaml
@@ -1,0 +1,9 @@
+slug: marketlens
+name: Marketlens
+url: https://marketlens.trade
+repo: https://github.com/marketlenstrade/marketlens-python
+category: data
+platforms: [polymarket]
+access: freemium
+description: "Tick-level Polymarket book history from March 2026 across the whole catalog, not just crypto, with a backtester that models queue position, latency and slippage. Free tier, then $39/mo."
+tags: [orderbook-history, backtesting, parquet, python-sdk]


### PR DESCRIPTION
Adds Marketlens to `Tools: data tooling`.

Paid, so per the section rule here is what it does that nothing free on the page does. The free sources cover crypto up/down: pmxt archive is hourly snapshots, the HF L2 depth tape is April to July 2026. Marketlens carries tick-level book history from 2026-03-01 across the whole Polymarket catalog, so sports, weather, earnings and rates markets have book depth too, and it ships a backtester that models queue position, latency, slippage and settlement delay rather than leaving execution to the caller. Against Probalytics, the entry already in this section, the difference is catalog breadth and the execution engine, not resolution.

- Data files only, no README in the diff.
- `python scripts/build.py --validate` passes (20 platforms, 10 sources, 40 tools).
- `github:` and `last_post:` omitted for the refresh bot.
- Python SDK is MIT: https://github.com/marketlenstrade/marketlens-python

Self-submission, on the record: I built it.
