### PR TITLE
sources: add Live Tennis API

### DIFF
--- a/data/sources/livetennisapi.yaml
+++ b/data/sources/livetennisapi.yaml
@@ -1,0 +1,13 @@
+slug: livetennisapi
+name: Live Tennis API
+url: https://livetennisapi.com
+kind: odds-feed
+prices: Tennis
+format: JSON REST / WebSocket / MCP
+granularity: live match state per point, plus fixtures, H2H and rankings
+coverage:
+  range: live + 1968-2022 results archive
+  completeness: partial
+  known_gaps: "Free tier is keyed and capped at 30 req/min and 100/day, and covers live scores, players, fixtures and usage only. Completed-match history needs a paid plan, and the WebSocket feed plus model win probability sit on the top tier."
+access: free
+description: "Live tennis match state and a deep results archive for building fair probabilities on tennis event markets - the event side, not bookmaker odds."


### PR DESCRIPTION
Adds `data/sources/livetennisapi.yaml` under odds and reference feeds — the tennis event side (live match state per point, fixtures, H2H, rankings, and a 1968–2022 results archive) for building fair probabilities to hold against Polymarket/Kalshi tennis prices. No tennis-specific feed is in the list today.

Per the house rules: data file only, `metrics`/`github`/`last_post` untouched, `scripts/build.py --validate` passes locally (20 platforms, 11 sources, 40 tools). The known_gaps field states the freemium split exactly: free tier is 30 req/min / 100 per day and covers live scores, players, fixtures and usage; completed-match history is paid; WebSocket + model win probability are top-tier.

**Submitting my own work** — I run this API (the CONTRIBUTING disclosure box, ticked in prose since PRs don't carry the form).