### PR TITLE
tools: add Dimes Multiply SDK (leveraged Polymarket execution)

### DIFF
--- a/data/tools/dimes-multiply-sdk.yaml
+++ b/data/tools/dimes-multiply-sdk.yaml
@@ -1,0 +1,14 @@
+slug: dimes-multiply-sdk
+name: Dimes Multiply SDK
+url: https://github.com/dimes-fi/multiply-sdk
+repo: https://github.com/dimes-fi/multiply-sdk
+category: bot
+platforms: [polymarket]
+github:
+  stars: null
+  last_commit: null
+  license: null
+  archived: null
+  health: null
+description: "TypeScript SDK for opening 2-10x leveraged Polymarket positions from a third-party front-end, putting the borrow, collateral and liquidation handling behind one call."
+tags: [typescript, leverage, margin, sdk]


### PR DESCRIPTION
Adds `data/tools/dimes-multiply-sdk.yaml` under Trading bots, agents & execution.

**Disclosure: this is my own project.** Putting that up front, per the "Submitting your own work" section.

**What it is.** A TypeScript SDK that lets a third-party front-end open leveraged Polymarket positions. You pass a market and a multiplier, it handles the borrow, the collateral posting and the liquidation accounting. MIT, published on npm as `@dimes-fi/multiply-sdk`.

**Why it might earn a row.** Nothing currently on the list touches leverage or margin. I grepped the README for leverage, margin, borrow and collateral and the only hit is the Rain exclusion note, which is about volume measurement rather than credit. Polymarket still has no native leverage on event contracts (the Perps product launched in August is BTC, equities and gold, which are continuous assets, not event outcomes), so leverage on event markets is only reachable through third-party infrastructure, and none of it is represented here.

**Where it is weak, so you can judge it fairly.** The repo is small: three source files, three commits, last touched 2026-04-15, and no stars. It is a thin client rather than a large codebase, and the refresh bot will likely mark it stale. I would rather state that than have you find it. If your bar is a more active repo, that is a reasonable no and I will not resubmit.

Seeded `github:` as nulls per CONTRIBUTING. No `README.md` in the diff. Description is 166 characters, straight quotes, no em dashes.
